### PR TITLE
Fix upload not working when the agent cannot be deployed

### DIFF
--- a/penelope.py
+++ b/penelope.py
@@ -2489,7 +2489,7 @@ class Session:
 
 		if self.OS == 'Unix':
 			# Get remote available space
-			remote_block_size = 1
+			remote_block_size = 1024
 			if self.agent:
 				response = self.exec(f"""
 				stats = os.statvfs('{destination}')
@@ -2499,7 +2499,7 @@ class Session:
 				remote_available_blocks, remote_block_size = map(int, response.split(';'))
 				remote_space = remote_available_blocks * remote_block_size
 			else:
-				remote_space = int(self.exec(f"df --block-size={remote_block_size} {destination}|tail -1|awk '{{print $4}}'", value=True))
+				remote_space = int(self.exec(f"df -k {destination}|tail -1|awk '{{print $4}}'", value=True))
 
 			# Calculate local size
 			local_size = 0

--- a/penelope.py
+++ b/penelope.py
@@ -2489,6 +2489,7 @@ class Session:
 
 		if self.OS == 'Unix':
 			# Get remote available space
+			remote_block_size = 1
 			if self.agent:
 				response = self.exec(f"""
 				stats = os.statvfs('{destination}')
@@ -2498,7 +2499,7 @@ class Session:
 				remote_available_blocks, remote_block_size = map(int, response.split(';'))
 				remote_space = remote_available_blocks * remote_block_size
 			else:
-				remote_space = int(self.exec(f"df --block-size=1 {destination}|tail -1|awk '{{print $4}}'", value=True))
+				remote_space = int(self.exec(f"df --block-size={remote_block_size} {destination}|tail -1|awk '{{print $4}}'", value=True))
 
 			# Calculate local size
 			local_size = 0


### PR DESCRIPTION
When the agent cannot be deployed the `upload` command fails as `remote_block_size` is not set. This commit sets `remote_block_size` to 1 by default.