### PR TITLE
Allow using `listeners stop any|all <port>`

### DIFF
--- a/penelope.py
+++ b/penelope.py
@@ -1097,10 +1097,10 @@ class MainMenu(BetterCMD):
 				return False
 
 			if subcommand == "add":
-				host = Interfaces().translate(host)
 				Listener(host, port)
 
 			elif subcommand == "stop":
+				host = Interfaces().translate(host)
 				for listener in core.listeners.values():
 					if (listener.host, listener.port) == (host, port):
 						listener.stop()


### PR DESCRIPTION
When adding a new listener, instead of using `0.0.0.0`, `any` or `all` can be used.
However, this is not possible when removing a listener. Therefore, against intuition, the following fails:
```
listeners add any 443
listeners stop any 443
```

This change allows the use of both `any` and `all` using the same logic at `stop` that's used at `add`:
```
listeners stop any <port>
listeners stop all <port>
```


As the `translate` method is called at the constructor of `Listener`, it's not necesary to canonicalize it explicitely beforehand at `listeners add`.