### PR TITLE
Emoji check fix

### DIFF
--- a/penelope.py
+++ b/penelope.py
@@ -4822,12 +4822,14 @@ def fonts_installed():
 
 	if myOS == "Darwin":
 		return True
-	try:
-		if "emoji" in subprocess.run(["fc-list"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout.lower():
-			return True
-	except:
-		pass
-	return False
+
+	result = subprocess.run(
+		["fc-list", ":charset=1f600"],  # 1F600 = smiling face
+		stdout=subprocess.PIPE,
+		stderr=subprocess.PIPE,
+		text=True
+	)
+	return bool(result.stdout.strip())
 
 # OPTIONS
 class Options:

--- a/penelope.py
+++ b/penelope.py
@@ -4819,20 +4819,11 @@ def load_rc():
 	os.chmod(RC, 0o600)
 
 def fonts_installed():
-	possible_paths = (
-		"/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf",
-		"/usr/share/fonts/noto/NotoColorEmoji.ttf",
-		"/usr/local/share/fonts/noto/NotoColorEmoji.ttf",
-		"/usr/local/share/fonts/noto-emoji/NotoColorEmoji.ttf"
-	)
 
-	for path in possible_paths:
-		if os.path.isfile(path):
-			return True
 	if myOS == "Darwin":
 		return True
 	try:
-		if "Noto Color Emoji" in subprocess.run(["fc-list"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout:
+		if "emoji" in subprocess.run(["fc-list"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout.lower():
 			return True
 	except:
 		pass


### PR DESCRIPTION
`Noto Color Emoji` isn't the only available emoji font. Personally, I use `Apple Color Emoji` since most of my devices are Apple—except for my ThinkPad running Arch (it makes things feel more consistent, haha).

Beyond personal preference, there are several other fonts that provide emoji support — such as `ttf-twemoji`, `ttf-joypixels`, `openmoji`, and more — though some are less common.

A more robust approach would be to check whether any installed font supports at least one emoji (e.g., `U+1F600`, the 😀 emoji). This would provide a more reliable indication that a working emoji font is present on the system, regardless of its name.
