### PR TITLE
Fix link of privesccheck

### DIFF
--- a/penelope.py
+++ b/penelope.py
@@ -5189,7 +5189,7 @@ URLS = {
 	'lse':          "https://raw.githubusercontent.com/diego-treitos/linux-smart-enumeration/master/lse.sh",
 	'powerup':      "https://raw.githubusercontent.com/PowerShellEmpire/PowerTools/master/PowerUp/PowerUp.ps1",
 	'deepce':       "https://raw.githubusercontent.com/stealthcopter/deepce/refs/heads/main/deepce.sh",
-	'privesccheck': "https://raw.githubusercontent.com/itm4n/PrivescCheck/refs/heads/master/PrivescCheck.ps1",
+	'privesccheck': "https://github.com/itm4n/PrivescCheck/releases/latest/download/PrivescCheck.ps1",
 	'les':          "https://raw.githubusercontent.com/The-Z-Labs/linux-exploit-suggester/refs/heads/master/linux-exploit-suggester.sh",
 	'ngrok_linux':  "https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-amd64.tgz",
 	'uac_linux':  	"https://github.com/tclahr/uac/releases/download/v3.1.0/uac-3.1.0.tar.gz",


### PR DESCRIPTION
The current URL of privesccheck is no longer valid.
Regarding the latest README.md of PrivescCheck, the latest script is here: https://github.com/itm4n/PrivescCheck/releases/latest/download/PrivescCheck.ps1