### PR TITLE
URLs: Update to latest releases

### DIFF
--- a/penelope.py
+++ b/penelope.py
@@ -5187,12 +5187,12 @@ URLS = {
 	'socat':        "https://raw.githubusercontent.com/andrew-d/static-binaries/master/binaries/linux/x86_64/socat",
 	'ncat':         "https://raw.githubusercontent.com/andrew-d/static-binaries/master/binaries/linux/x86_64/ncat",
 	'lse':          "https://raw.githubusercontent.com/diego-treitos/linux-smart-enumeration/master/lse.sh",
-	'powerup':      "https://raw.githubusercontent.com/PowerShellEmpire/PowerTools/master/PowerUp/PowerUp.ps1",
+	'powerup':      "https://raw.githubusercontent.com/PowerShellMafia/PowerSploit/refs/heads/master/Privesc/PowerUp.ps1",
 	'deepce':       "https://raw.githubusercontent.com/stealthcopter/deepce/refs/heads/main/deepce.sh",
 	'privesccheck': "https://github.com/itm4n/PrivescCheck/releases/latest/download/PrivescCheck.ps1",
 	'les':          "https://raw.githubusercontent.com/The-Z-Labs/linux-exploit-suggester/refs/heads/master/linux-exploit-suggester.sh",
 	'ngrok_linux':  "https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-amd64.tgz",
-	'uac_linux':  	"https://github.com/tclahr/uac/releases/download/v3.1.0/uac-3.1.0.tar.gz",
+	'uac_linux':  	"https://github.com/tclahr/uac/releases/download/v3.2.0/uac-3.2.0.tar.gz",
 	'linux_procmemdump':  	"https://raw.githubusercontent.com/tclahr/uac/refs/heads/main/bin/linux/linux_procmemdump.sh",
 }
 


### PR DESCRIPTION
This PR brings two URL updates:
- Use of the latest UAC version 3.2.0
- Use of PowerShellMafia's repo for PowerUp which contains the latest (although still 8yo compared to the current 10yo) script as suggested in PowerShellEmpire's README.