### PR TITLE
Add version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   <img src="https://github.com/user-attachments/assets/0d369fba-480e-4e27-a117-8845dbd4b58e" alt="Logo" width="200"/>
 </div>
 <div align="center">
+  <img src="https://img.shields.io/badge/version-0.14.10-blueviolet"/><br>
   <img src="https://raw.githubusercontent.com/toolswatch/badges/refs/heads/master/arsenal/europe/2024.svg?sanitize=true"/><br>
   <img src="https://img.shields.io/badge/Black%20Hat%20Arsenal-USA%202025-red"/><br>
   <img src="https://img.shields.io/badge/Black%20Hat%20Arsenal-MEA%202025-green"/>


### PR DESCRIPTION
Adds a version badge to the README to display the current version (0.14.10) in the header section alongside existing badges.

Motivation:
Currently, the version in the code differs from release tags, which can cause confusion for users. Adding the version badge to the README provides clear visibility of the current version.
