### PR TITLE
Add automated version management and PyPI publishing workflow

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -35,14 +35,16 @@ jobs:
       run: |
         git diff HEAD^ HEAD -- penelope.py | grep -q "__version__" && echo "changed=true" >> $GITHUB_OUTPUT || echo "changed=false" >> $GITHUB_OUTPUT
     
-    - name: Check if minor version changed
-      id: minor_changed
+    - name: Check if minor or major version changed
+      id: release_version
       run: |
         PREV_VERSION=$(git show HEAD^:penelope.py | grep -oP '__version__\s*=\s*["'\'']?\K[0-9.]+')
         CURR_VERSION=${{ steps.get_version.outputs.version }}
+        PREV_MAJOR=$(echo $PREV_VERSION | cut -d. -f1)
+        CURR_MAJOR=$(echo $CURR_VERSION | cut -d. -f1)
         PREV_MINOR=$(echo $PREV_VERSION | cut -d. -f2)
         CURR_MINOR=$(echo $CURR_VERSION | cut -d. -f2)
-        if [ "$CURR_MINOR" -gt "$PREV_MINOR" ]; then
+        if [ "$CURR_MAJOR" -gt "$PREV_MAJOR" ] || [ "$CURR_MINOR" -gt "$PREV_MINOR" ]; then
           echo "changed=true" >> $GITHUB_OUTPUT
         else
           echo "changed=false" >> $GITHUB_OUTPUT
@@ -72,7 +74,7 @@ jobs:
         git push
     
     - name: Create GitHub Release
-      if: steps.minor_changed.outputs.changed == 'true'
+      if: steps.release_version.outputs.changed == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -83,14 +85,14 @@ jobs:
           --target main
     
     - name: Build package
-      if: steps.minor_changed.outputs.changed == 'true'
+      if: steps.release_version.outputs.changed == 'true'
       run: |
         python -m pip install --upgrade pip
         pip install build
         python -m build
     
     - name: Publish to PyPI
-      if: steps.minor_changed.outputs.changed == 'true'
+      if: steps.release_version.outputs.changed == 'true'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Hey! This implements the automated versioning workflow we discussed and closes #99. 

Basically, whenever you update `__version__` in `penelope.py`, the action will:
- Sync the version across `pyproject.toml` and README automatically
- Create a GitHub release
- Publish to PyPI

## Setup needed after merging

### 1. PyPI API Token
You'll need to add your PyPI token as a secret:

1. Head to https://pypi.org/manage/account/token/
2. Create a new token (I'd recommend scoping it to just Penelope)
3. Copy it (starts with `pypi-`)
4. In your repo, go to **Settings** → **Secrets and variables** → **Actions**
5. Hit **"New repository secret"**
6. Name it `PYPI_API_TOKEN` and paste the token
7. Save it

### 2. Workflow permissions
The action needs permission to commit the version syncs:

1. Go to **Settings** → **Actions** → **General**
2. Find **"Workflow permissions"**
3. Pick **"Read and write permissions"**
4. Enable **"Allow GitHub Actions to create and approve pull requests"**
5. Save

## Testing it out
Once set up, just:
1. Bump `__version__` in `penelope.py` (like to `0.14.17`)
2. Push to `main`
3. The action takes care of the rest

## A few notes:
1. If you modify file paths or structure later, you'll need to update the `.yml` file accordingly
2. Failed runs won't block your pushes - just check the **Actions** tab if something breaks
3. The workflow only triggers on `main` branch, so if you want to test changes without actually publishing to PyPI, test on a different branch first, then merge to main when you're ready to release

Let me know if anything needs tweaking!