### PR TITLE
chore: configure ruff as read-only linter, explicitly respect tab indentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,18 @@
 
 [tool.setuptools]
   py-modules = ["penelope"]
+
+[tool.ruff]
+  fix = false
+
+[tool.ruff.lint]
+  fixable = []
+  unfixable = ["ALL"]
+  select = ["E", "W", "F"]
+  ignore = ["W191", "E101", "E111"]
+
+[tool.ruff.lint.isort]
+  force-single-line = true
+
+[tool.ruff.format]
+  exclude = ["*.py"]


### PR DESCRIPTION
This PR introduces `pyproject.toml` additions to prevent IDE tooling from making automatic changes to the files.
To be noted: anyone that has automatic import sorting will still have changes but it's only a setting toggle to fix it:)

This follows the github discussion on the matter.