### PR TITLE
Remove security vulnerability due to duplicate in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Security vulnerability
-    url: https://github.com/brightio/penelope/security/policy
-    about: Please don't open a public issue for security bugs. Check the security policy and report it privately.
   - name: Question or usage help
     url: https://github.com/brightio/penelope/discussions
     about: For usage questions and general discussion, please use Discussions.


### PR DESCRIPTION
## What does this PR do?

Removes the security vulnerability contact link from the issue template becaues it now shows 2 choices of that.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] My change keeps Penelope dependency-free (standard library only)
- [x] I tested this manually and described how below
- [x] I considered compatibility with older Python versions (3.6+)
- [x] I updated the README or help text if the change affects usage