### PR TITLE
Do not crash on upload paths Path.glob() refuses

### DIFF
--- a/penelope.py
+++ b/penelope.py
@@ -4477,10 +4477,17 @@ class Session:
 				except Exception as e:
 					logger.error(e)
 			else:
-				if os.path.isabs(item):
-					items = list(Path('/').glob(item.lstrip('/')))
-				else:
-					items = list(Path().glob(item))
+				try:
+					if os.path.isabs(item):
+						items = list(Path('/').glob(item.lstrip('/')))
+					else:
+						items = list(Path().glob(item))
+				except (ValueError, IndexError, NotImplementedError):
+					# Path.glob() refuses '.', './' and '' outright, and `upload /`
+					# reduces to the empty pattern. The exception differs by version
+					# (IndexError up to 3.12, ValueError from 3.13). They are still
+					# valid paths, so fall through to the existence check below.
+					items = []
 				if items:
 					resolved_items.extend(items)
 				elif os.path.lexists(item):


### PR DESCRIPTION
### Problem

`Session.upload()` hands every non-URL argument straight to `Path.glob()` (`penelope.py:4509-4512`). `Path.glob()` refuses a handful of perfectly ordinary paths, so `upload myfile .` dies with an uncaught traceback instead of uploading anything:

```
  File "penelope.py", line 1446, in do_upload
    core.sessions[self.sid].upload(local_items, remote_path=remote_folder, ...)
  File "penelope.py", line 4512, in upload
    items = list(Path().glob(item))
  File ".../pathlib/_local.py", line 592, in glob
    raise ValueError("Unacceptable pattern: {!r}".format(pattern))
ValueError: Unacceptable pattern: PosixPath('.')
```

`upload <file> .` is a natural thing to type, since `download <file> .` takes a destination in that position.

Affected patterns, and the exception each raises:

| pattern | exception |
| --- | --- |
| `Path().glob('.')` | `ValueError` (3.13+), `IndexError` (≤ 3.12) |
| `Path().glob('')` | same |
| `Path().glob('./')` | same |
| `Path('/').glob('')` | same — this is what `upload /` reduces to, since the absolute branch strips the leading slash |
| `Path().glob('/')` | `NotImplementedError` |

Verified on 3.10.12, 3.12.12, 3.13.9 and 3.14.6: it raises on every one, only the exception type differs.

### Fix

Catch those and fall through to the `os.path.lexists()` branch immediately below, which already handles a literal (non-glob) path correctly. `upload myfile .` then uploads the file and the current directory, as it reads.

### Verification

Drove the menu through 20 `upload` shapes against a local reverse shell — plain file, directory, glob, `~` path, trailing `.`, `./`, `''`, `-o <folder>`, name with spaces, name containing `[]`, broken symlink, good symlink, 200 KB binary, nonexistent path, no args, unclosed quote, `/`, `..`, a local HTTP URL and a GitHub raw URL.

- before: `upload <file> .`, `upload <file> ./` and `upload <file> ''` each produced the traceback above
- after: no tracebacks in any of the 20; the remaining error lines are the correct ones (genuinely missing paths, the deliberately broken symlink)
- files confirmed to land on the target with correct contents

No behaviour change for any argument `Path.glob()` already accepted — the `try` only widens what reaches the existing `lexists` fallback.